### PR TITLE
Swapped out the default safeAreaView for Expo's cross compatable version

### DIFF
--- a/src/screens/TrainSuperhero.js
+++ b/src/screens/TrainSuperhero.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import {
   Animated,
-  SafeAreaView,
   Text,
   View,
   StyleSheet,
@@ -11,6 +10,7 @@ import {
 import styles from "../stylesheets/screens/trainSuperheroStyles";
 import kpiData from "../data/kpiData";
 import exerciseData from "../data/trainSuperheroData";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 /**
  * Custom Hook created by Dan Abramov


### PR DESCRIPTION
- Swapped SafeAreaView 
- trainSuperhero was previously using the default SafeAreaView which isn't cross-platform compatible.
